### PR TITLE
Fix an error on Windows

### DIFF
--- a/amica15win.bat
+++ b/amica15win.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal enabledelayedexpansion
+
+for /f "tokens=1 delims==" %%I in ('set') do (
+    echo %%I | find /i "KMP" >nul
+    if not errorlevel 1 (
+        set "%%I="
+    )
+)
+
+%~dp0amica15mkl.exe %*

--- a/runamica15.m
+++ b/runamica15.m
@@ -97,7 +97,7 @@
 function [weights,sphere,mods] = runamica15(dat,varargin)
 
 if ispc
-    binfile = 'amica15mkl.exe'; % on computing
+    binfile = 'amica15win.bat'; % on computing
 elseif ismac
     binfile = 'amica15mac';
 else


### PR DESCRIPTION
I am using AMICA on Windows LTSC 2021 with MATLAB R2024b.
It looks like environment variables
```
KMP_BLOCKTIME=1
KMP_HANDLE_SIGNALS=0
KMP_STACKSIZE=512k
__KMP_REGISTERED_LIB_12476=00007FFAD5934D04-cafe4fb8-libiomp5md.dll
```
set by MATLAB are interfering with the normal operation, causing AMICA to crash when `do_opt_block` is enabled.
This PR tries to fix this issue, at least it worked for me.